### PR TITLE
chore: update ancient issue time

### DIFF
--- a/.github/workflows/stale_issue.yml
+++ b/.github/workflows/stale_issue.yml
@@ -41,7 +41,7 @@ jobs:
         # Issue timing
         days-before-stale: 5
         days-before-close: 2
-        days-before-ancient: 365
+        days-before-ancient: 36500
 
         # If you don't want to mark a issue as being ancient based on a
         # threshold of "upvotes", you can set this here. An "upvote" is


### PR DESCRIPTION
Update ancient issue time so that we are not automatically closing old GitHub issues.